### PR TITLE
fix: evaluate flag when passing evalCtx

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -399,11 +399,10 @@ func (p *Provider) evaluateFlag(ctx context.Context, flag string, evalCtx openfe
 		attr[k] = v
 	}
 
-	//nolint:errcheck
-	p.gbClient.WithAttributes(attr)
+	client, _ := p.gbClient.WithAttributes(attr)
 
 	// Evaluate the feature in GrowthBook
-	return p.gbClient.EvalFeature(ctx, flag)
+	return client.EvalFeature(ctx, flag)
 }
 
 // createResolutionDetail creates a ProviderResolutionDetail from a GrowthBook feature result


### PR DESCRIPTION
Fix issue that caused attributes not to being applied when evaluating context.

`p.gbClient.WithAttributes(attr)` does not mutate existing client, (p.gbClient) but returns a new one, with new attributes.
New client should be used to evaluate feature flag