### PR TITLE
fix: return error when flag does not exist

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -140,7 +140,7 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultVa
 	feature := p.evaluateFlag(ctx, flag, evalCtx)
 
 	// Flag not found
-	if feature == nil {
+	if feature == nil || feature.Source == gb.UnknownFeatureResultSource {
 		return openfeature.BoolResolutionDetail{
 			Value: defaultValue,
 			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
@@ -191,7 +191,7 @@ func (p *Provider) StringEvaluation(ctx context.Context, flag string, defaultVal
 	feature := p.evaluateFlag(ctx, flag, evalCtx)
 
 	// Flag not found
-	if feature == nil {
+	if feature == nil || feature.Source == gb.UnknownFeatureResultSource {
 		return openfeature.StringResolutionDetail{
 			Value: defaultValue,
 			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
@@ -242,7 +242,7 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValu
 	feature := p.evaluateFlag(ctx, flag, evalCtx)
 
 	// Flag not found
-	if feature == nil {
+	if feature == nil || feature.Source == gb.UnknownFeatureResultSource {
 		return openfeature.FloatResolutionDetail{
 			Value: defaultValue,
 			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
@@ -304,7 +304,7 @@ func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue 
 	feature := p.evaluateFlag(ctx, flag, evalCtx)
 
 	// Flag not found
-	if feature == nil {
+	if feature == nil || feature.Source == gb.UnknownFeatureResultSource {
 		return openfeature.IntResolutionDetail{
 			Value: defaultValue,
 			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
@@ -366,7 +366,7 @@ func (p *Provider) ObjectEvaluation(ctx context.Context, flag string, defaultVal
 	feature := p.evaluateFlag(ctx, flag, evalCtx)
 
 	// Flag not found
-	if feature == nil {
+	if feature == nil || feature.Source == gb.UnknownFeatureResultSource {
 		return openfeature.InterfaceResolutionDetail{
 			Value: defaultValue,
 			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{

--- a/provider_test.go
+++ b/provider_test.go
@@ -31,17 +31,17 @@ func setupTestProvider() *Provider {
 			}
 		},
 		"rules-test": {
-            "defaultValue": false,
-            "rules": [
-                {
-                    "id": "rule_id",
-                    "condition": {
-                        "email": "user@growthbook.com"
-                    },
+			"defaultValue": false,
+			"rules": [
+				{
+					"id": "rule_id",
+					"condition": {
+						"email": "user@growthbook.com"
+					},
 					"force": true
-                }
-            ]
-        }
+				}
+			]
+		}
 	}`
 
 	gbClient, _ := gb.NewClient(
@@ -233,5 +233,19 @@ func TestEvaluateFlagWithRule(t *testing.T) {
 				t.Errorf("evaluateFlag returned %v, expected %v", directResult.On, tt.expectedResult)
 			}
 		})
+	}
+}
+
+func TestEvaluateNonExistingFlag(t *testing.T) {
+	provider := setupTestProvider()
+
+	_ = provider.Init(openfeature.NewEvaluationContext("test-user", nil))
+	result := provider.BooleanEvaluation(context.Background(), "non-existent-flag", false, nil)
+
+	if result.Reason != openfeature.ErrorReason {
+		t.Error("expected error reason for non-existent flag")
+	}
+	if result.ResolutionError.Error() != "FLAG_NOT_FOUND: flag 'non-existent-flag' not found" {
+		t.Error("expected resolution error to be equal to FLAG_NOT_FOUND: flag 'non-existent-flag' not found")
 	}
 }


### PR DESCRIPTION
According to https://openfeature.dev/specification/types/#error-code
Provider should return `FLAG_NOT_FOUND` code when flag does not exist

Currently `evaluateFlag ` never returns null, however keeping this as it could change in future